### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # EMQX MCP Server
 [![smithery badge](https://smithery.ai/badge/@Benniu/emqx-mcp-server)](https://smithery.ai/server/@Benniu/emqx-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/m7zgbcr053">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/m7zgbcr053/badge" alt="emqx-mcp-server MCP server" />
+</a>
+
 A [Model Context Protocol (MCP)](https://www.anthropic.com/news/model-context-protocol) server implementation that provides EMQX MQTT broker interaction.
 Enabling MCP clients to interact with the MQTT clusters on [EMQX Cloud](https://www.emqx.com/en/cloud/serverless-mqtt) or self-hosted clusters
 


### PR DESCRIPTION
This PR adds a badge for the [emqx-mcp-server](https://glama.ai/mcp/servers/m7zgbcr053) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/m7zgbcr053">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/m7zgbcr053/badge" alt="emqx-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.